### PR TITLE
feat: Add Control Plane Authority samples and update README content for gke-custom-org-policy.

### DIFF
--- a/gke-custom-org-policy/samples/README.md
+++ b/gke-custom-org-policy/samples/README.md
@@ -27,3 +27,11 @@ gcloud org-policies set-policy gke_custom_org_policy.yaml
 ### For more information visit:
 [https://cloud.google.com/kubernetes-engine/docs/how-to/custom-org-policies](https://cloud.google.com/kubernetes-engine/docs/how-to/custom-org-policies)
 
+## GKE Control Plane Authority
+
+The following samples pertain to [GKE Control Plane Authority](https://cloud.google.com/kubernetes-engine/docs/concepts/about-control-plane-authority). Note: This is a general availability feature or capability that's only available to use on request. To use this feature, contact your Google Cloud account team.
+
+* [control_plane_user_managed_keys.yaml](control-plane-authority/control_plane_user_managed_keys.yaml)
+* [control_plane_ssh_logs.yaml](control-plane-authority/control_plane_ssh_logs.yaml)
+* [control_plane_network_connection.yaml](control-plane-authority/samples/control_plane_network_connection.yaml)
+

--- a/gke-custom-org-policy/samples/control-plane-authority/control_plane_network_connection.yaml
+++ b/gke-custom-org-policy/samples/control-plane-authority/control_plane_network_connection.yaml
@@ -1,0 +1,10 @@
+name: organizations/${ORG_ID}/customConstraints/custom.controlPlaneNetworkConnectionLogs
+resource_types: container.googleapis.com/Cluster
+method_types:
+ - CREATE
+ - UPDATE
+condition: resource.loggingConfig.componentConfig.enableComponents.exists(component, component=="KCP_CONNECTION")
+action_type: ALLOW
+display_name: GKE Control Plane Authority Network Connection Logs Visibility
+description: Only allow Clusters to be created and updated when GKE Control Plane Authority network connections logs visibility is enabled.
+

--- a/gke-custom-org-policy/samples/control-plane-authority/control_plane_ssh_logs.yaml
+++ b/gke-custom-org-policy/samples/control-plane-authority/control_plane_ssh_logs.yaml
@@ -1,0 +1,10 @@
+name: organizations/${ORG_ID}/customConstraints/custom.controlPlaneSSHLogs
+resource_types: container.googleapis.com/Cluster
+method_types:
+ - CREATE
+ - UPDATE
+condition: resource.loggingConfig.componentConfig.enableComponents.exists(component, component=="KCP_SSHD")
+action_type: ALLOW
+display_name: GKE Control Plane Authority SSH Logs Visibility
+description: Only allow Clusters to be created and updated when GKE Control Plane Authority SSH logs visibility is enabled.
+

--- a/gke-custom-org-policy/samples/control-plane-authority/control_plane_user_managed_keys.yaml
+++ b/gke-custom-org-policy/samples/control-plane-authority/control_plane_user_managed_keys.yaml
@@ -1,0 +1,10 @@
+name: organizations/${ORG_ID}/customConstraints/custom.controlPlaneUserManagedKeys
+resource_types: container.googleapis.com/Cluster
+method_types:
+ - CREATE
+ - UPDATE
+condition: resource.userManagedKeysConfig.clusterCa.startsWith("/projects/${PROJECT_ID}") && resource.userManagedKeysConfig.etcdApiCa.startsWith("/projects/${PROJECT_ID}") && resource.userManagedKeysConfig.etcdPeerCa.startsWith("/projects/${PROJECT_ID}") && resource.userManagedKeysConfig.aggregationCa.startsWith("/projects/${PROJECT_ID}") && resource.userManagedKeysConfig.controlPlaneDiskEncryptionKey.startsWith("/projects/${PROJECT_ID}") && resource.userManagedKeysConfig.gkeopsEtcdBackupEncryptionKey.startsWith("/projects/${PROJECT_ID}") && resource.userManagedKeysConfig.serviceAccountSigningKeys.all(key, key.startsWith("/projects/${PROJECT_ID}")) && resource.userManagedKeysConfig.serviceAccountVerificationKeys.all(key, key.startsWith("/projects/${PROJECT_ID}"))
+action_type: ALLOW
+display_name: GKE Control Plane Authority CMEK
+description: Only allow Clusters to be created and updated with GKE Control Plane Authority features, namely inputting the Cluster CA, etcd-API CA, etcd-peer CA, service account signing & verification key, etcd backup encryption key, and the control plane boot disk & etcd storage key housed in Certificate Authority Service and Cloud KMS from specific project.
+


### PR DESCRIPTION
Add custom constraints example for Control Plane Authority use cases.