### PR TITLE
feat: Add another example constraint for CPA user managed keys.

### DIFF
--- a/gke-custom-org-policy/samples/control-plane-authority/control_plane_user_managed_keys_must_exist.yaml
+++ b/gke-custom-org-policy/samples/control-plane-authority/control_plane_user_managed_keys_must_exist.yaml
@@ -1,0 +1,9 @@
+name: organizations/${ORG_ID}/customConstraints/custom.controlPlaneUserManagedKeys
+resource_types: container.googleapis.com/Cluster
+method_types:
+ - CREATE
+ - UPDATE
+condition: resource.userManagedKeysConfig.clusterCa != "" && resource.userManagedKeysConfig.etcdApiCa != "" && resource.userManagedKeysConfig.etcdPeerCa != "" && resource.userManagedKeysConfig.aggregationCa != "" && resource.userManagedKeysConfig.controlPlaneDiskEncryptionKey != "" && resource.userManagedKeysConfig.gkeopsEtcdBackupEncryptionKey != "" && size(resource.userManagedKeysConfig.serviceAccountSigningKeys) != 0 && size(resource.userManagedKeysConfig.serviceAccountVerificationKeys) != 0
+action_type: ALLOW
+display_name: GKE Control Plane Authority CMEK
+description: Only allow Clusters to be created and updated with GKE Control Plane Authority features, namely inputting the Cluster CA, etcd-API CA, etcd-peer CA, service account signing & verification key, etcd backup encryption key, and the control plane boot disk & etcd storage key.

--- a/gke-custom-org-policy/samples/control-plane-authority/control_plane_user_managed_keys_must_start_with_project_id.yaml
+++ b/gke-custom-org-policy/samples/control-plane-authority/control_plane_user_managed_keys_must_start_with_project_id.yaml
@@ -7,4 +7,3 @@ condition: resource.userManagedKeysConfig.clusterCa.startsWith("projects/${PROJE
 action_type: ALLOW
 display_name: GKE Control Plane Authority CMEK
 description: Only allow Clusters to be created and updated with GKE Control Plane Authority features, namely inputting the Cluster CA, etcd-API CA, etcd-peer CA, service account signing & verification key, etcd backup encryption key, and the control plane boot disk & etcd storage key housed in Certificate Authority Service and Cloud KMS from specific project.
-


### PR DESCRIPTION
Include both cases with and without specified project id in prefix in CPA user managed keys constraints, differentiating the 2 constraints in file names and folder README.