### PR TITLE
feat: Add "gke-volume-populator-role" and "system:gcp-controller-manager" ClusterRoles to exclusions

### DIFF
--- a/anthos-bundles/cis-gke-v1.5.0/require-namespace-networkpolicy.yaml
+++ b/anthos-bundles/cis-gke-v1.5.0/require-namespace-networkpolicy.yaml
@@ -58,6 +58,7 @@ spec:
       - apigee-system
       - gke-managed-system
       - gke-managed-cim
+      - gke-managed-volumepopulator
     kinds:
       - apiGroups:
           - ""

--- a/anthos-bundles/cis-gke-v1.5.0/restrict-persistent-volume.yaml
+++ b/anthos-bundles/cis-gke-v1.5.0/restrict-persistent-volume.yaml
@@ -50,6 +50,7 @@ spec:
         - name: admin
         - name: cluster-admin
         - name: config-management-operator
+        - name: gke-volume-populator-role
         - name: pdcsi-provisioner-role
         - name: system:controller:persistent-volume-binder
         - name: system:persistent-volume-provisioner

--- a/anthos-bundles/cis-gke-v1.5.0/restrict-role-secrets.yaml
+++ b/anthos-bundles/cis-gke-v1.5.0/restrict-role-secrets.yaml
@@ -91,6 +91,7 @@ spec:
         - name: system:controller:generic-garbage-collector
         - name: system:controller:namespace-controller
         - name: system:controller:persistent-volume-binder
+        - name: system:gcp-controller-manager
         - name: system:kube-controller-manager
         - name: vmruntime-vmruntime-manager-role
         # for GKE

--- a/anthos-bundles/cis-gke-v1.5.0/restrict-serviceaccounts-token.yaml
+++ b/anthos-bundles/cis-gke-v1.5.0/restrict-serviceaccounts-token.yaml
@@ -51,6 +51,7 @@ spec:
         - name: cluster-admin
         - name: config-management-operator
         - name: edit
+        - name: gke-volume-populator-role
         - name: servicemesh
         - name: system:aggregate-to-edit
         - name: system:cloud-controller-manager

--- a/anthos-bundles/cis-k8s-v1.7.1/require-namespace-networkpolicy.yaml
+++ b/anthos-bundles/cis-k8s-v1.7.1/require-namespace-networkpolicy.yaml
@@ -58,6 +58,7 @@ spec:
       - apigee-system
       - gke-managed-system
       - gke-managed-cim
+      - gke-managed-volumepopulator
     kinds:
       - apiGroups:
           - ""

--- a/anthos-bundles/cis-k8s-v1.7.1/restrict-persistent-volume.yaml
+++ b/anthos-bundles/cis-k8s-v1.7.1/restrict-persistent-volume.yaml
@@ -50,6 +50,7 @@ spec:
         - name: admin
         - name: cluster-admin
         - name: config-management-operator
+        - name: gke-volume-populator-role
         - name: pdcsi-provisioner-role
         - name: system:controller:persistent-volume-binder
         - name: system:persistent-volume-provisioner

--- a/anthos-bundles/cis-k8s-v1.7.1/restrict-role-secrets.yaml
+++ b/anthos-bundles/cis-k8s-v1.7.1/restrict-role-secrets.yaml
@@ -91,6 +91,7 @@ spec:
         - name: system:controller:generic-garbage-collector
         - name: system:controller:namespace-controller
         - name: system:controller:persistent-volume-binder
+        - name: system:gcp-controller-manager
         - name: system:kube-controller-manager
         - name: vmruntime-vmruntime-manager-role
         # for GKE

--- a/anthos-bundles/cis-k8s-v1.7.1/restrict-serviceaccounts-token.yaml
+++ b/anthos-bundles/cis-k8s-v1.7.1/restrict-serviceaccounts-token.yaml
@@ -51,6 +51,7 @@ spec:
         - name: cluster-admin
         - name: config-management-operator
         - name: edit
+        - name: gke-volume-populator-role
         - name: servicemesh
         - name: system:aggregate-to-edit
         - name: system:cloud-controller-manager

--- a/anthos-bundles/mitre-v2024/require-namespace-networkpolicy.yaml
+++ b/anthos-bundles/mitre-v2024/require-namespace-networkpolicy.yaml
@@ -58,6 +58,7 @@ spec:
       - apigee-system
       - gke-managed-system
       - gke-managed-cim
+      - gke-managed-volumepopulator
     kinds:
       - apiGroups:
           - ""

--- a/anthos-bundles/mitre-v2024/restrict-role-secrets.yaml
+++ b/anthos-bundles/mitre-v2024/restrict-role-secrets.yaml
@@ -92,6 +92,7 @@ spec:
         - name: system:controller:namespace-controller
         - name: system:controller:persistent-volume-binder
         - name: system:kube-controller-manager
+        - name: system:gcp-controller-manager
         - name: vmruntime-vmruntime-manager-role
         # for GKE
         - name: admin


### PR DESCRIPTION
Fixes #254,
Fixes #255

- [feat: Allow "system:gcp-controller-manager" ClusterRole to manage secrets](https://github.com/GoogleCloudPlatform/gke-policy-library/commit/f9ff52e2d9c187c57ca6682b91584130790e1bb2) 
GKE updated that role in one of the recent GKE upgrades (most likely, 1.31.6-gke.1020000). Now it's supposed to manage secrets, so `K8sRestrictRoleRules` should be updated accordingly.

- [feat: Allow "gke-volume-populator-role" ClusterRole to manage PVs and SA tokens](https://github.com/GoogleCloudPlatform/gke-policy-library/commit/e8d7e5df2a05c711164fd0b0d1cafe53585e5188) 
Starting from GKE 1.31.6-gke.1020000 the Volume Populator component is enabled by default.
It brings the ClusterRole "gke-volume-populator-role" which is supposed to manage
"serviceaccounts/token" and "persistentvolumes" resources, so `K8sRestrictRoleRules` should be updated accordingly.

- [feat: Allow "gke-managed-volumepopulator" namespace to do not have NetworkPolicies](https://github.com/GoogleCloudPlatform/gke-policy-library/pull/250/commits/bb88576884cd4c84eb957d8e144b84ed2b324c8a) 
This namespace and its content is managed by GKE.